### PR TITLE
Update refresh interval to 15m30s

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple browser extension that automatically refreshes DAT load board pages on 
 
 ## ⚙️ Features
 
-- Auto-refreshes DAT load board every 15 minutes
+- Auto-refreshes DAT load board every 15 minutes and 30 seconds
 - Clean popup UI with start/stop toggle, timer, and refresh count
 - Works with both Chrome and Edge
 - Lightweight — no tracking, no login credentials needed or saved
@@ -52,7 +52,7 @@ Once installed:
   ![Extensions Bar](Screenshots/extensions.png)
 
 - Click **Start**
-- The script will now auto-refresh your posts every 15 minutes
+- The script will now auto-refresh your posts every 15 minutes and 30 seconds
 
 Still refreshes when on a different tab or if browser is minimized. DAT tab must stay on 'My Shipments' to refresh.
 

--- a/background.js
+++ b/background.js
@@ -29,11 +29,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     refreshInterval = Math.max(15, message.interval || 15);
 
     chrome.alarms.create("datRefreshAlarm", {
-      periodInMinutes: refreshInterval + (7 / 60)
+      // Refresh every 15 minutes and 30 seconds
+      periodInMinutes: refreshInterval + (30 / 60)
     });
 
     count = 1;
-    nextRefresh = Date.now() + (refreshInterval * 60000) + 7000;
+    // 30 second buffer after each 15 minute interval
+    nextRefresh = Date.now() + (refreshInterval * 60000) + 30000;
     isRunning = true;
 
     chrome.storage.local.set({
@@ -87,7 +89,8 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     // Retrieve the latest count in case the service worker was restarted
     chrome.storage.local.get(["count"], (res) => {
       count = (res.count || 0) + 1;
-      nextRefresh = Date.now() + (refreshInterval * 60000) + 7000;
+      // Schedule the next refresh for 15 minutes and 30 seconds from now
+      nextRefresh = Date.now() + (refreshInterval * 60000) + 30000;
 
       chrome.storage.local.set({
         count,

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "DAT Tools",
   "version": "3.0",
-  "description": "Automatically refresh DAT loadboard posts every 15 minutes and copy coworker's posts. Updated for new DAT UI.",
+  "description": "Automatically refresh DAT loadboard posts every 15 minutes and 30 seconds and copy coworker's posts. Updated for new DAT UI.",
 
   "permissions": [
     "alarms",


### PR DESCRIPTION
## Summary
- bump automatic refresh interval to 15 minutes 30 seconds
- adjust scheduled timer and countdown
- update docs and manifest description

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e58d7db0883298cd61f92ba7e9e1e