### PR TITLE
Add smart refresh delay

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -15,7 +15,7 @@ toggle.addEventListener("change", () => {
 
   chrome.runtime.sendMessage({ action, interval }, (res) => {
     if (action === "start") {
-      label.textContent = "Running";
+      label.textContent = res.isDelayed ? "Refresh Delayed" : "Running";
       startCountdown(res.nextRefresh);
     } else {
       label.textContent = "Stopped";
@@ -55,7 +55,9 @@ function startCountdown(timestamp) {
 // 🔄 Restore state when popup opens
 chrome.runtime.sendMessage({ action: "getStatus" }, (data) => {
   toggle.checked = data.isRunning;
-  label.textContent = data.isRunning ? "Running" : "Stopped";
+  label.textContent = data.isRunning
+    ? data.isDelayed ? "Refresh Delayed" : "Running"
+    : "Stopped";
   countDisplay.textContent = data.count.toString();
 
   darkToggle.checked = data.darkMode;
@@ -72,6 +74,10 @@ chrome.runtime.sendMessage({ action: "getStatus" }, (data) => {
 chrome.runtime.onMessage.addListener((message) => {
   if (message.action === "updateCount") {
     countDisplay.textContent = message.count.toString();
+  }
+  if (message.action === "updateNextRefresh") {
+    label.textContent = message.isDelayed ? "Refresh Delayed" : "Running";
+    startCountdown(message.nextRefresh);
   }
 });
 


### PR DESCRIPTION
## Summary
- track delayed refresh state in background worker
- check posted load timers in content script before refreshing
- update popup UI to show delayed state and refresh time

## Testing
- `node --check background.js`
- `node --check content.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6884e5361cd48329ba94cd4ac035904f