### PR TITLE
Enable coworker copy feature

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -31,7 +31,7 @@
 
   <div class="section">
     <h4>Copy Coworker's Posts</h4>
-    <p>This feature is still being worked on and is disabled for this release.</p>
+    <p>This feature is used to copy a coworker's posts. Navigate to a single coworker's posts and click Copy.</p>
     <button id="copyCoworkerBtn">Copy</button>
   </div>
 

--- a/popup.js
+++ b/popup.js
@@ -74,5 +74,11 @@ function startClock(stamp) {
   timerID = setInterval(tick, 1000);
 }
 
-/* Easter-egg placeholder */
-egg.addEventListener("click", () => alert("👀 Curious? Coming soon!"));
+/* Trigger copy coworker posts in active tab */
+egg.addEventListener("click", () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    if (tabs.length) {
+      chrome.tabs.sendMessage(tabs[0].id, { action: "copyCoworker" });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- re-enable copy button in popup and update instructions
- handle `copyCoworker` action in content script
- implement new coworker copy routine that tracks row-ids and confirms before copying

## Testing
- `node --check content.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_688b7ed5872483298d0cab83c8edb7ec